### PR TITLE
Fix "NameError: global name 'time' is not defined" exception

### DIFF
--- a/Code/physicsTable/visualize/__init__.py
+++ b/Code/physicsTable/visualize/__init__.py
@@ -1,3 +1,4 @@
+import time
 from warnings import warn
 
 


### PR DESCRIPTION
Added import time statement to __init__ in visualize to avoid undefined name error (e.g., line 20).